### PR TITLE
systemd unit install to default.target

### DIFF
--- a/templates/systemd.vm
+++ b/templates/systemd.vm
@@ -10,3 +10,5 @@ Type=forking
 ExecStart=${w_start_cmd}
 ExecStop=${w_stop_cmd}
 
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
systemd unit file need to have install section to enable service.
default.tagret seems to be good default for template